### PR TITLE
fixed eslint and prettier for windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   rules: {
     'import/no-extraneous-dependencies': 'off',
-    'prettier/prettier': 'error',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
     'import/no-unresolved': 'off',
     'import/no-named-as-default': 0,
     'import/extensions': 'off',
@@ -61,6 +61,7 @@ module.exports = {
     // 'unused-imports/no-unused-imports': 'error',
     // 'unused-imports/no-unused-vars': 'error',
     'unicorn/no-null': 'off',
+    'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
   },
   settings: {
     react: {

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,10 +1,10 @@
 module.exports = {
-    semi: true,
-    // Trailing commas help with git merging and conflict resolution
-    trailingComma: 'all',
-    singleQuote: true,
-    printWidth: 120,
-    tabWidth: 2,
-    jsxBracketSameLine: true,
-    arrowParens: 'avoid',
+  semi: true,
+  // Trailing commas help with git merging and conflict resolution
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 120,
+  tabWidth: 2,
+  jsxBracketSameLine: true,
+  arrowParens: 'avoid',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint": "^8.44.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint-config-prettier": "^8.10.0",
         "eslint-formatter-pretty": "^5.0.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.27.5",
@@ -8197,9 +8197,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^8.44.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^8.8.0",
+    "eslint-config-prettier": "^8.10.0",
     "eslint-formatter-pretty": "^5.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.27.5",


### PR DESCRIPTION
Every time I changed the branch, I had ESLint and Prettier errors (Delete CR (prettier/prettier)) that would disappear when I ran the lint:fix command, even though there were no actual code changes. I decided to fix this issue. Similarly, after running the lint:fix command, I had many modified files, which was inconvenient. Just a reminder, I'm working on Windows, so please check if my changes don't cause any issues on your OS.